### PR TITLE
Update to not require python-magic

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,11 @@ package:
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/mastodon_py-{{ version }}.tar.gz
   sha256: 6602e9ca4db37c70b5adae5964d02e9a529f6cc8473947a314261008add208a5
+  patches:
+    - python-magic.patch
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
@@ -24,7 +26,6 @@ requirements:
     - python >={{ python_min }}
     - requests >=2.4.2
     - python-dateutil
-    - python-magic
     - decorator >=4.0.0
     - blurhash >=1.1.4
 

--- a/recipe/python-magic.patch
+++ b/recipe/python-magic.patch
@@ -1,12 +1,11 @@
---- mastodon_py-2.1.4.orig/pyproject.toml	2025-09-23 06:38:35.000000000 -0300
-+++ mastodon_py-2.1.4/pyproject.toml	2026-02-05 10:11:26.214063491 -0300
-@@ -23,8 +23,7 @@
+--- mastodon_py-2.1.4.orig/pyproject.toml	2026-02-05 14:39:30.383916144 -0600
++++ mastodon_py-2.1.4/pyproject.toml	2026-02-05 14:39:46.694947578 -0600
+@@ -23,8 +23,6 @@
  dependencies = [
      'requests>=2.4.2',
      'python-dateutil',
 -    'python-magic-bin ; platform_system=="Windows"',
 -    'python-magic ; platform_system!="Windows"',
-+    'python-magic',
      'decorator>=4.0.0',
      'blurhash>=1.1.4',
  ]


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

@conda-forge-admin please rerender

This reverts the python-magic dep change in #30 and patches mastodon.py to remove the dep there, so `pip check` is happy.